### PR TITLE
sha256 block

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-        module: ["sha1"]
+        module: ["sha1", "sha256"]
 
     steps:
       - uses: actions/checkout@v3

--- a/hw/sha256/sha256.sv
+++ b/hw/sha256/sha256.sv
@@ -1,0 +1,87 @@
+// ------------------------------------------------------
+//  Module name: sha256
+//  Description: sha256 top-level with register inteface
+// ------------------------------------------------------
+
+module sha256 #(
+    parameter int unsigned DataWidth = 64,
+    parameter int unsigned AddrWidth = 32,
+    parameter int unsigned DataBytes = DataWidth >> 3,
+    parameter bit          ByteAlign = 1
+) (
+    input  logic                 clk_i,             // Clock
+    input  logic                 rst_ni,            // Reset
+
+    input  logic [DataWidth-1:0] sha_s_reqdata_i,   // Data bus request
+    input  logic [AddrWidth-1:0] sha_s_reqaddr_i,   // Addr bus request
+    input  logic                 sha_s_reqvalid_i,  // Valid requets
+    input  logic                 sha_s_reqwrite_i,  // Write request
+    output logic                 sha_s_reqready_o,  // Ready signal
+    input  logic [DataBytes-1:0] sha_s_reqstrobe_i, // Strobe
+
+    input  logic                 sha_s_rspready_i,  // Response ready
+    output logic                 sha_s_rspvalid_o,  // Response valid
+    output logic [DataWidth-1:0] sha_s_rspdata_o,   // Data bus response
+    output logic                 sha_s_rsperror_o,  // Error response
+
+    input  logic                 sha_process_i,     // Start algorithm pulse
+    input  logic                 sha_digestack_i,   // Acknowledge digest
+    output logic [255:0]         sha_digest_o,      // Hash digest
+    output logic                 sha_digestvalid_o  // Hash digest valid
+);
+
+    // Calculate internal parameters
+    localparam int unsigned BlockWidth = 512;
+
+    logic [BlockWidth-1:0] sha_block;
+    logic enable_hash, rst_hash;
+    
+    logic [6:0] round;
+    logic [63:0] cycle;
+
+    reg_interface #(
+        .DataWidth(DataWidth),
+        .AddrWidth(AddrWidth),
+        .BlockWidth(BlockWidth),
+        .ByteAlign(ByteAlign)
+    ) u_sha256_reg_interface (
+        .clk_i,
+        .rst_ni,
+        .reqdata_i   ( sha_s_reqdata_i   ),
+        .reqaddr_i   ( sha_s_reqaddr_i   ),
+        .reqvalid_i  ( sha_s_reqvalid_i  ),
+        .reqwrite_i  ( sha_s_reqwrite_i  ),
+        .reqready_o  ( sha_s_reqready_o  ),
+        .reqstrobe_i ( sha_s_reqstrobe_i ),
+        .rspready_i  ( sha_s_rspready_i  ),
+        .rspvalid_o  ( sha_s_rspvalid_o  ),
+        .rspdata_o   ( sha_s_rspdata_o   ),
+        .rsperror_o  ( sha_s_rsperror_o  ),
+        .block_o     ( sha_block         )
+    );
+
+    // TODO: determine how we want to validate the registers when computing the hash value
+    // assign sha_regsfixed = ~(reqwrite & |sha_regssel);
+    // assign sha_regsvalid = (sha_process_i | sha_regsvalid_q) & ~sha_regsfixed;
+
+    assign enable_hash = 1'b1;
+    assign rst_hash = 1'b0;
+
+    sha256_core #(
+        .BlockWidth(BlockWidth)
+    ) u_sha256_core (
+        .clk_i,
+        .rst_ni,
+        .block_i        ( sha_block    ),
+        .enable_hash_i  ( enable_hash  ),
+        .rst_hash_i     ( rst_hash     ),
+        .round_o        ( round        ),
+        .cycle_o        ( cycle        ),
+        .digest_o       ( digest       ),
+        .digest_valid_o ( digest_valid ),
+    );
+
+    assign sha_digest_o      = digest;
+    assign sha_digestvalid_o = digest_valid;
+
+endmodule

--- a/hw/sha256/sha256_core.sv
+++ b/hw/sha256/sha256_core.sv
@@ -1,0 +1,100 @@
+// ------------------------------------------------------
+//  Module name: sha256 core
+//  Description: sha256 algorithm and control unit
+// ------------------------------------------------------
+
+module sha256_core #(
+    parameter int unsigned BlockWidth = 512
+) (
+    input  logic                  clk_i,            // Clock
+    input  logic                  rst_ni,           // Reset
+
+    input  logic [BlockWidth-1:0] block_i,          // sha block
+    output logic                  enable_hash_i,    // Enable hash algorith
+    output logic                  rst_hash_i,       // Reset hash algorith
+    
+    output logic [6:0]            round_o,          // Round number (0..79)
+    output logic [63:0]           cycle_o,          // Acknowledge digest
+    output logic [255:0]          sha_digest_o,     // Hash digest
+    output logic                  sha_digestvalid_o // Hash digest valid
+);
+
+    // finite state machine to control hashing
+    typedef enum logic [2:0] { 
+        IDLE    = 3'h0,
+        HASHING = 3'h1,
+        HOLD    = 3'h2,
+        DONE    = 3'h3
+    } sha_fsm_e;
+
+    // sha256 and sha224 digest initial values
+    integer H0 = 32'h6A09E667;
+    integer H1 = 32'hBB67AE85;
+    integer H2 = 32'h3C6EF372;
+    integer H3 = 32'hA54FF53A;
+    integer H4 = 32'h510E527F;
+    integer H5 = 32'h9B05688C;
+    integer H6 = 32'h1F83D9AB;
+    integer H7 = 32'h5BE0CD19;
+
+    // k constant used by sha256 and sha224 algorithm
+    integer k[64] = {
+        32'h428a2f98,32'h71374491,32'hb5c0fbcf,32'he9b5dba5,32'h3956c25b,32'h59f111f1,32'h923f82a4,32'hab1c5ed5,
+        32'hd807aa98,32'h12835b01,32'h243185be,32'h550c7dc3,32'h72be5d74,32'h80deb1fe,32'h9bdc06a7,32'hc19bf174,
+        32'he49b69c1,32'hefbe4786,32'h0fc19dc6,32'h240ca1cc,32'h2de92c6f,32'h4a7484aa,32'h5cb0a9dc,32'h76f988da,
+        32'h983e5152,32'ha831c66d,32'hb00327c8,32'hbf597fc7,32'hc6e00bf3,32'hd5a79147,32'h06ca6351,32'h14292967,
+        32'h27b70a85,32'h2e1b2138,32'h4d2c6dfc,32'h53380d13,32'h650a7354,32'h766a0abb,32'h81c2c92e,32'h92722c85,
+        32'ha2bfe8a1,32'ha81a664b,32'hc24b8b70,32'hc76c51a3,32'hd192e819,32'hd6990624,32'hf40e3585,32'h106aa070,
+        32'h19a4c116,32'h1e376c08,32'h2748774c,32'h34b0bcb5,32'h391c0cb3,32'h4ed8aa4a,32'h5b9cca4f,32'h682e6ff3,
+        32'h748f82ee,32'h78a5636f,32'h84c87814,32'h8cc70208,32'h90befffa,32'ha4506ceb,32'hbef9a3f7,32'hc67178f2
+    };
+
+    logic [BlockWidth-1:0] sha_block;
+    logic [63:0]           msg_length;
+    logic enable_hash, rst_hash;
+    
+    logic [7:0]  round;
+    logic [63:0] cycle;
+
+    sha_fsm_e current_state, next_state;
+
+    always_comb begin : sha_control
+        
+        next_state = current_state;
+
+        case (current_state) begin
+            
+            IDLE: begin
+            
+            end
+
+            HASHING: begin
+
+            end
+            
+            HOLD: begin
+
+            end
+
+            DONE: begin
+
+            end
+
+        endcase
+    end
+
+    always_ff @(posedge clk_i, negedge rst_ni ) begin : sha_fsm_ff
+        if (~rst_ni) begin
+            current_state <= IDLE;
+        end else begin
+            current_state <= next_state;
+        end
+    end
+
+    assign round_o = round;
+    assign cycle_o = cycle;
+    
+    assign sha_digest_o      = digest;
+    assign sha_digestvalid_o = digest_valid;
+
+endmodule

--- a/tb/sha256/model/sha256.py
+++ b/tb/sha256/model/sha256.py
@@ -1,0 +1,183 @@
+import struct
+from typing import List
+
+
+def right_rotate(x, n):
+    """Rotation to the right function"""
+    return (x >> n) | (x << (32 - n))
+
+
+class sha256:
+    """Class implementing the SHA-256 algorithm"""
+
+    k = [
+        0x428A2F98,
+        0x71374491,
+        0xB5C0FBCF,
+        0xE9B5DBA5,
+        0x3956C25B,
+        0x59F111F1,
+        0x923F82A4,
+        0xAB1C5ED5,
+        0xD807AA98,
+        0x12835B01,
+        0x243185BE,
+        0x550C7DC3,
+        0x72BE5D74,
+        0x80DEB1FE,
+        0x9BDC06A7,
+        0xC19BF174,
+        0xE49B69C1,
+        0xEFBE4786,
+        0x0FC19DC6,
+        0x240CA1CC,
+        0x2DE92C6F,
+        0x4A7484AA,
+        0x5CB0A9DC,
+        0x76F988DA,
+        0x983E5152,
+        0xA831C66D,
+        0xB00327C8,
+        0xBF597FC7,
+        0xC6E00BF3,
+        0xD5A79147,
+        0x06CA6351,
+        0x14292967,
+        0x27B70A85,
+        0x2E1B2138,
+        0x4D2C6DFC,
+        0x53380D13,
+        0x650A7354,
+        0x766A0ABB,
+        0x81C2C92E,
+        0x92722C85,
+        0xA2BFE8A1,
+        0xA81A664B,
+        0xC24B8B70,
+        0xC76C51A3,
+        0xD192E819,
+        0xD6990624,
+        0xF40E3585,
+        0x106AA070,
+        0x19A4C116,
+        0x1E376C08,
+        0x2748774C,
+        0x34B0BCB5,
+        0x391C0CB3,
+        0x4ED8AA4A,
+        0x5B9CCA4F,
+        0x682E6FF3,
+        0x748F82EE,
+        0x78A5636F,
+        0x84C87814,
+        0x8CC70208,
+        0x90BEFFFA,
+        0xA4506CEB,
+        0xBEF9A3F7,
+        0xC67178F2,
+    ]
+
+    def __init__(self, debug=False, encoding="ascii"):
+        self._h = [
+            0x6A09E667,
+            0xBB67AE85,
+            0x3C6EF372,
+            0xA54FF53A,
+            0x510E527F,
+            0x9B05688C,
+            0x1F83D9AB,
+            0x5BE0CD19,
+        ]
+        self._encoding = encoding
+        self._debug = debug
+        self._dbg_hash_values = []
+
+    def process(self, message):
+        _pre_message = self._pre_processing(message)
+        l = len(_pre_message)
+        N = l // 64
+
+        if self._debug:
+            print(f"(N = {N})")
+
+        for m in range(0, l, 64):
+            block = _pre_message[m : m + 64]
+            self._process_block(block)
+            self._dbg_hash_values.append(self.digest())
+
+        return self.digest()
+
+    def _pre_processing(self, message):
+        _bin_message = bytearray(message, encoding=self._encoding)
+        ml = len(_bin_message) * 8
+
+        if self._debug:
+            print(f"\nMessage length: {ml} bits ", end="")
+
+        _bin_message.append(0x80)
+        while (len(_bin_message) + 8) % 64 != 0:
+            _bin_message.append(0x00)
+
+        _bin_message += struct.pack(">Q", ml)
+
+        return _bin_message
+
+    def _process_block(self, block):
+        assert len(block) == 64
+        w = [0] * 64
+
+        for i in range(16):
+            w[i] = struct.unpack(">I", block[i * 4 : i * 4 + 4])[0]
+
+        for i in range(16, 64):
+            s0 = (
+                right_rotate(w[i - 15], 7)
+                ^ right_rotate(w[i - 15], 18)
+                ^ (w[i - 15] >> 3)
+            )
+            s1 = (
+                right_rotate(w[i - 2], 17)
+                ^ right_rotate(w[i - 2], 19)
+                ^ (w[i - 2] >> 10)
+            )
+            w[i] = (w[i - 16] + s0 + w[i - 7] + s1) & 0xFFFFFFFF
+
+        a, b, c, d, e, f, g, h = self._h
+
+        for i in range(64):
+            s1 = right_rotate(e, 6) ^ right_rotate(e, 11) ^ right_rotate(e, 25)
+            ch = (e & f) ^ (~e & g)
+            temp1 = (h + s1 + ch + self.k[i] + w[i]) & 0xFFFFFFFF
+            s0 = right_rotate(a, 2) ^ right_rotate(a, 13) ^ right_rotate(a, 22)
+            maj = (a & b) ^ (a & c) ^ (b & c)
+            temp2 = (s0 + maj) & 0xFFFFFFFF
+
+            h = g
+            g = f
+            f = e
+            e = (d + temp1) & 0xFFFFFFFF
+            d = c
+            c = b
+            b = a
+            a = (temp1 + temp2) & 0xFFFFFFFF
+
+        self._h[0] = (self._h[0] + a) & 0xFFFFFFFF
+        self._h[1] = (self._h[1] + b) & 0xFFFFFFFF
+        self._h[2] = (self._h[2] + c) & 0xFFFFFFFF
+        self._h[3] = (self._h[3] + d) & 0xFFFFFFFF
+        self._h[4] = (self._h[4] + e) & 0xFFFFFFFF
+        self._h[5] = (self._h[5] + f) & 0xFFFFFFFF
+        self._h[6] = (self._h[6] + g) & 0xFFFFFFFF
+        self._h[7] = (self._h[7] + h) & 0xFFFFFFFF
+
+    def digest(self):
+        return "".join(format(x, "08x") for x in self._h)
+
+    def _dbg_digest(self):
+        N = len(self._dbg_hash_values)
+
+        if N > 1:
+            for i in range(N - 1):
+                print(f"Intermediate hash value (H({i})): {self._dbg_hash_values[i]}")
+
+        print(f"Final hash value: {self._dbg_hash_values[-1]}")

--- a/tb/sha256/model/test_sha256.py
+++ b/tb/sha256/model/test_sha256.py
@@ -1,0 +1,38 @@
+from sha256 import sha256
+
+
+def test_one_block_message() -> None:
+    """One-block message from FIPS sha256 examples"""
+
+    message: str = "abc"
+
+    sha256_model = sha256(debug=True, encoding="ascii")
+
+    sha256_model.process(message)
+    sha256_model._dbg_digest()
+
+    assert (
+        sha256_model.digest()
+        == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    )
+
+
+def test_multi_block_message() -> None:
+    """Multi-block message from FIPS sha256 examples"""
+
+    message: str = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+
+    sha256_model = sha256(debug=True, encoding="ascii")
+
+    sha256_model.process(message)
+    sha256_model._dbg_digest()
+
+    assert (
+        sha256_model._dbg_hash_values[0]
+        == "85e655d6417a17953363376a624cde5c76e09589cac5f811cc4b32c1f20e533a"
+    )
+
+    assert (
+        sha256_model.digest()
+        == "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+    )


### PR DESCRIPTION
This PR adds the RTL design, Python model and tests, cocotb tests for the sha256 algorithm. By extension, it also adds support for the sha224 algorithm since the only differences is that the last 32-bit word is cut out.