### PR TITLE
sha256 extension for sha224

### DIFF
--- a/hw/sha256/sha256.sv
+++ b/hw/sha256/sha256.sv
@@ -25,8 +25,6 @@ module sha256 #(
     output logic [DataWidth-1:0] sha_s_rspdata_o,   // Data bus response
     output logic                 sha_s_rsperror_o,  // Error response
 
-    input  logic                 sha_process_i,     // Start algorithm pulse
-    input  logic                 sha_digestack_i,   // Acknowledge digest
     output logic [255:0]         sha_digest_o,      // Hash digest
     output logic                 sha_digestvalid_o  // Hash digest valid
 );
@@ -37,8 +35,10 @@ module sha256 #(
 
     logic [BlockWidth-1:0] sha_block;
 
-    logic enable_hash, rst_hash;
-    logic idle, hold;
+    logic enable_hash
+    logic rst_hash;
+    logic idle
+    logic hold;
 
     logic [DigestWidth-1:0] digest;
     logic                   digest_valid;
@@ -77,8 +77,9 @@ module sha256 #(
         .block_i        ( sha_block    ),
         .enable_hash_i  ( enable_hash  ),
         .rst_hash_i     ( rst_hash     ),
+        .hold_o         ( hold         ),
+        .idle_o         ( idle         ),
         .round_o        (              ), // TBD: Not connected for now
-        .cycle_o        (              ), // TBD: Not connected for now
         .digest_o       ( digest       ),
         .digest_valid_o ( digest_valid ),
     );

--- a/hw/sha256/sha256_core.sv
+++ b/hw/sha256/sha256_core.sv
@@ -375,6 +375,6 @@ module sha256_core #(
     // user available data is computed here
     // digest valid bit and digest on 256 or 224 bits
     assign sha_digestvalid_o = digest_valid_q;
-    assign sha_digest_o      = digest_q[DigestWidth-1:0];
+    assign sha_digest_o      = digest_q[255:256-DigestWidth];
 
 endmodule

--- a/tb/sha256/model/sha256.py
+++ b/tb/sha256/model/sha256.py
@@ -77,8 +77,18 @@ class sha256:
         0xC67178F2,
     ]
 
-    def __init__(self, debug=False, encoding="ascii"):
-        self._h = [
+    def __init__(self, sha224=False, debug=False, encoding="ascii"):
+        sha224_h = [
+            0xC1059ED8,
+            0x367CD507,
+            0x3070DD17,
+            0xF70E5939,
+            0xFFC00B31,
+            0x68581511,
+            0x64F98FA7,
+            0xBEFA4FA4,
+        ]
+        sha256_h = [
             0x6A09E667,
             0xBB67AE85,
             0x3C6EF372,
@@ -88,6 +98,9 @@ class sha256:
             0x1F83D9AB,
             0x5BE0CD19,
         ]
+
+        self._h = sha224_h if sha224 else sha256_h
+        self._truncate_hash = sha224
         self._encoding = encoding
         self._debug = debug
         self._dbg_hash_values = []
@@ -182,6 +195,8 @@ class sha256:
         self._h[7] = (self._h[7] + h) & 0xFFFFFFFF
 
     def digest(self):
+        if self._truncate_hash:
+            return "".join(format(x, "08x") for x in self._h[0:7])
         return "".join(format(x, "08x") for x in self._h)
 
     def _dbg_digest(self):

--- a/tb/sha256/model/test_sha256.py
+++ b/tb/sha256/model/test_sha256.py
@@ -16,6 +16,15 @@ def test_one_block_message() -> None:
         == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
     )
 
+    sha224_model = sha256(sha224=True, debug=True, encoding="ascii")
+
+    sha224_model.process(message)
+
+    assert (
+        sha224_model.digest()
+        == "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7"
+    )
+
 
 def test_multi_block_message() -> None:
     """Multi-block message from FIPS sha256 examples"""
@@ -35,4 +44,13 @@ def test_multi_block_message() -> None:
     assert (
         sha256_model.digest()
         == "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+    )
+
+    sha224_model = sha256(sha224=True, encoding="ascii")
+
+    sha224_model.process(message)
+
+    assert (
+        sha224_model.digest()
+        == "75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525"
     )


### PR DESCRIPTION
__Merge after #28 and #30__ 


Extends the RTL and testbench to support the sha224 implementation of the sha256 algorithm.
Performs general cleanup in the RTL to finalize the implementation.

Closes #23 